### PR TITLE
Add cancel button to TUI

### DIFF
--- a/XKCD_archiver/downloader.py
+++ b/XKCD_archiver/downloader.py
@@ -56,6 +56,11 @@ class Downloader:
         self.max_retries = max_retries
         self.progress_callback = progress_callback
         self._thread_local = threading.local()
+        self._cancel_event = threading.Event()
+
+    def cancel(self) -> None:
+        """Signal all workers to stop."""
+        self._cancel_event.set()
 
     def _get_session(self) -> requests.Session:
         """Get or create a per-thread requests.Session."""
@@ -95,6 +100,8 @@ class Downloader:
         return True
 
     def _download_one(self, comic_number: int, total: int) -> DownloadProgress:
+        if self._cancel_event.is_set():
+            return DownloadProgress(comic_number, total, "skipped", "cancelled")
         session = self._get_session()
         for attempt in range(self.max_retries):
             try:
@@ -142,6 +149,7 @@ class Downloader:
         Returns:
             List of DownloadProgress results for each comic processed.
         """
+        self._cancel_event.clear()
         self.output_dir.mkdir(exist_ok=True)
 
         session = self._get_session()
@@ -156,6 +164,10 @@ class Downloader:
             futures = {pool.submit(self._download_one, num, total): num for num in comic_numbers}
 
             for future in as_completed(futures):
+                if self._cancel_event.is_set():
+                    for f in futures:
+                        f.cancel()
+                    break
                 progress = future.result()
                 results.append(progress)
                 self._report(progress.comic_number, progress.total, progress.status, progress.error)

--- a/XKCD_archiver/tui.py
+++ b/XKCD_archiver/tui.py
@@ -54,7 +54,7 @@ class XKCDArchiverApp(App):
         self._failed = 0
         self._total = 0
         self._downloader: Downloader | None = None
-        self._running = False
+        self._downloading = False  # was named _running but that collided with Textual internal var.
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -77,7 +77,7 @@ class XKCDArchiverApp(App):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "start-btn":
-            if self._running:
+            if self._downloading:
                 self._cancel_download()
             else:
                 self._start_download()
@@ -94,7 +94,7 @@ class XKCDArchiverApp(App):
         except ValueError:
             workers = 10
 
-        self._running = True
+        self._downloading = True
         start_btn.label = "Cancel"
         start_btn.variant = "error"
 
@@ -187,7 +187,7 @@ class XKCDArchiverApp(App):
             f"{status} Downloaded: {self._downloaded}, Skipped: {self._skipped}, Failed: {self._failed} in {runtime}"
         )
 
-        self._running = False
+        self._downloading = False
         self._downloader = None
         start_btn = self.query_one("#start-btn", Button)
         start_btn.label = "Start"

--- a/XKCD_archiver/tui.py
+++ b/XKCD_archiver/tui.py
@@ -1,5 +1,7 @@
 """Textual TUI for XKCD archiver."""
 
+import time
+
 from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -51,6 +53,8 @@ class XKCDArchiverApp(App):
         self._skipped = 0
         self._failed = 0
         self._total = 0
+        self._downloader: Downloader | None = None
+        self._running = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -73,7 +77,10 @@ class XKCDArchiverApp(App):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "start-btn":
-            self._start_download()
+            if self._running:
+                self._cancel_download()
+            else:
+                self._start_download()
 
     def _start_download(self) -> None:
         mode_select = self.query_one("#mode-select", Select)
@@ -87,8 +94,9 @@ class XKCDArchiverApp(App):
         except ValueError:
             workers = 10
 
-        start_btn.disabled = True
-        start_btn.label = "Running..."
+        self._running = True
+        start_btn.label = "Cancel"
+        start_btn.variant = "error"
 
         self._downloaded = 0
         self._skipped = 0
@@ -101,31 +109,34 @@ class XKCDArchiverApp(App):
 
         self._run_download(mode, workers)
 
+    def _cancel_download(self) -> None:
+        if self._downloader:
+            self._downloader.cancel()
+        log = self.query_one("#log", RichLog)
+        log.write("[yellow]Cancelling...[/]")
+
     @work(thread=True)
     def _run_download(self, mode: str, workers: int) -> None:
         def on_progress(p: DownloadProgress) -> None:
             self.call_from_thread(self._update_progress, p)
 
-        downloader = Downloader(
+        self._downloader = Downloader(
             max_workers=workers,
             progress_callback=on_progress,
         )
 
-        # Get total first for progress bar
         import requests
 
         session = requests.Session()
-        latest = downloader._get_latest_comic(session)
+        latest = self._downloader._get_latest_comic(session)
         session.close()
 
         total = min(100, latest) if mode == "quick" else latest
 
         self.call_from_thread(self._set_total, total)
 
-        import time
-
         start = time.time()
-        downloader.download_comics(mode=mode)
+        self._downloader.download_comics(mode=mode)
         elapsed = time.time() - start
 
         self.call_from_thread(self._download_complete, elapsed)
@@ -168,14 +179,19 @@ class XKCDArchiverApp(App):
             runtime = f"{mins:.0f}m {sec:.1f}s"
         else:
             runtime = f"{elapsed:.1f}s"
+
+        was_cancelled = self._downloader and self._downloader._cancel_event.is_set()
+        status = "[yellow]Cancelled[/]" if was_cancelled else "[bold]Done![/]"
+
         log.write(
-            f"[bold]Done![/] Downloaded: {self._downloaded}, Skipped: {self._skipped}, "
-            f"Failed: {self._failed} in {runtime}"
+            f"{status} Downloaded: {self._downloaded}, Skipped: {self._skipped}, Failed: {self._failed} in {runtime}"
         )
 
+        self._running = False
+        self._downloader = None
         start_btn = self.query_one("#start-btn", Button)
-        start_btn.disabled = False
         start_btn.label = "Start"
+        start_btn.variant = "primary"
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Start button toggles to a red Cancel button while a download is running
- Clicking Cancel signals workers to stop via `threading.Event`
- Pending futures are cancelled, in-progress workers finish their current comic then stop
- Completion message shows "Cancelled" in yellow with partial stats

## Test plan
- [ ] `uv run pytest -m "not integration"` — all tests pass
- [ ] `uv run xkcd-tui` — start a full mode download, click Cancel mid-run, verify it stops promptly
- [ ] After cancel, verify Start button resets and a new run can be started