### PR TITLE
Add configurable output path to CLI and TUI

### DIFF
--- a/XKCD_archiver/downloadXKCD.py
+++ b/XKCD_archiver/downloadXKCD.py
@@ -2,8 +2,10 @@
 downloadXKCD.py - Downloads every single XKCD comic.
 """
 
+import argparse
 import sys
 import time
+from pathlib import Path
 
 from XKCD_archiver.downloader import Downloader
 
@@ -75,14 +77,23 @@ def select_mode() -> str:
     return run_mode_selector()
 
 
-def cli_run() -> None:
-    script_tagline()
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Downloads every single XKCD comic.")
+    parser.add_argument("--mode", "-m", choices=["quick", "full"], help="Download mode (interactive if omitted)")
+    parser.add_argument("--output", "-o", type=Path, default=Path("xkcd"), help="Output directory (default: xkcd)")
+    parser.add_argument("--workers", "-w", type=int, default=10, help="Number of concurrent workers (default: 10)")
+    return parser.parse_args(argv)
 
+
+def cli_run(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    script_tagline()
     env_indicator()
 
-    mode = select_mode()
+    mode = args.mode if args.mode else select_mode()
 
-    downloader = Downloader()
+    downloader = Downloader(output_dir=args.output, max_workers=args.workers)
 
     timed_run(downloader, mode)
 

--- a/XKCD_archiver/tui.py
+++ b/XKCD_archiver/tui.py
@@ -1,6 +1,7 @@
 """Textual TUI for XKCD archiver."""
 
 import time
+from pathlib import Path
 
 from textual import work
 from textual.app import App, ComposeResult
@@ -24,6 +25,9 @@ class XKCDArchiverApp(App):
     }
     #workers-input {
         width: 12;
+    }
+    #output-input {
+        width: 30;
     }
     #start-btn {
         margin-left: 2;
@@ -68,6 +72,8 @@ class XKCDArchiverApp(App):
             )
             yield Label(" Workers: ")
             yield Input(value="10", id="workers-input", type="integer", max_length=3)
+            yield Label(" Output: ")
+            yield Input(value="xkcd", id="output-input")
             yield Button("Start", id="start-btn", variant="primary")
         with Vertical(id="progress-area"):
             yield ProgressBar(id="progress", total=100, show_eta=True)
@@ -85,9 +91,11 @@ class XKCDArchiverApp(App):
     def _start_download(self) -> None:
         mode_select = self.query_one("#mode-select", Select)
         workers_input = self.query_one("#workers-input", Input)
+        output_input = self.query_one("#output-input", Input)
         start_btn = self.query_one("#start-btn", Button)
 
         mode = str(mode_select.value)
+        output_dir = Path(output_input.value.strip() or "xkcd")
         try:
             workers = int(workers_input.value)
             workers = max(1, min(workers, 50))
@@ -105,9 +113,9 @@ class XKCDArchiverApp(App):
 
         log = self.query_one("#log", RichLog)
         log.clear()
-        log.write(f"Starting {mode} mode with {workers} workers...")
+        log.write(f"Starting {mode} mode with {workers} workers, output: {output_dir}")
 
-        self._run_download(mode, workers)
+        self._run_download(mode, workers, output_dir)
 
     def _cancel_download(self) -> None:
         if self._downloader:
@@ -116,12 +124,13 @@ class XKCDArchiverApp(App):
         log.write("[yellow]Cancelling...[/]")
 
     @work(thread=True)
-    def _run_download(self, mode: str, workers: int) -> None:
+    def _run_download(self, mode: str, workers: int, output_dir: Path) -> None:
         def on_progress(p: DownloadProgress) -> None:
             self.call_from_thread(self._update_progress, p)
 
         self._downloader = Downloader(
             max_workers=workers,
+            output_dir=output_dir,
             progress_callback=on_progress,
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the CLI module."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ import pytest
 from XKCD_archiver.downloadXKCD import (
     env_indicator,
     is_venv,
+    parse_args,
     run_mode_selector,
     script_tagline,
     timed_run,
@@ -76,6 +78,40 @@ class TestScriptTagline:
         script_tagline()
         output = capsys.readouterr().out
         assert "xkcd.com" in output
+
+
+class TestParseArgs:
+    def test_defaults(self):
+        args = parse_args([])
+        assert args.mode is None
+        assert args.output == Path("xkcd")
+        assert args.workers == 10
+
+    def test_mode_quick(self):
+        args = parse_args(["--mode", "quick"])
+        assert args.mode == "quick"
+
+    def test_mode_full(self):
+        args = parse_args(["-m", "full"])
+        assert args.mode == "full"
+
+    def test_output(self, tmp_path):
+        args = parse_args(["--output", str(tmp_path / "comics")])
+        assert args.output == tmp_path / "comics"
+
+    def test_output_short(self, tmp_path):
+        args = parse_args(["-o", str(tmp_path / "comics")])
+        assert args.output == tmp_path / "comics"
+
+    def test_workers(self):
+        args = parse_args(["--workers", "5"])
+        assert args.workers == 5
+
+    def test_all_flags(self, tmp_path):
+        args = parse_args(["-m", "quick", "-o", str(tmp_path), "-w", "20"])
+        assert args.mode == "quick"
+        assert args.output == tmp_path
+        assert args.workers == 20
 
 
 class TestEnvIndicator:


### PR DESCRIPTION
## Summary
- CLI: add `--output`/`-o`, `--mode`/`-m`, `--workers`/`-w` flags via argparse
- TUI: add output path input field
- Interactive mode selector still used when `--mode` is omitted

## Test plan
- [ ] `uv run pytest -m "not integration"` — 51 tests pass
- [ ] `uv run xkcd-archiver --mode quick --output /tmp/test-xkcd` — downloads to custom path
- [ ] `uv run xkcd-tui` — change output field, verify comics download to specified directory