### PR TITLE
Bump version to 3.1.0 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-12
+### Added
+- Embed alt text, title, source URL, and date into downloaded images (PNG tEXt, JPEG EXIF, GIF comment)
+- Configurable output directory via CLI `--output`/`-o` flag and TUI input field
+- CLI flags: `--mode`/`-m`, `--workers`/`-w` via argparse
+- Cancel button in TUI to stop downloads mid-run
+- Integration tests against real xkcd.com API
+
+### Fixed
+- Image download failures (e.g. comics 1608, 1668) now correctly reported as skipped
+
 ## [3.0.0] - 2026-04-12
 ### Changed
 - Replace raw `threading.Thread` with `ThreadPoolExecutor` and per-thread sessions

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ uv sync
 
 ### CLI
 ```bash
-uv run xkcd-archiver
-# or
-uv run python -m XKCD_archiver
+uv run xkcd-archiver                              # interactive mode selector
+uv run xkcd-archiver --mode full                   # skip interactive prompt
+uv run xkcd-archiver --mode quick --output ~/comics --workers 20
 ```
 
 ### TUI
@@ -26,7 +26,13 @@ uv run xkcd-tui
 uv run python -m XKCD_archiver --tui
 ```
 
-The TUI provides a progress bar, live download log, and configurable worker count.
+The TUI provides a progress bar, live download log, configurable worker count, output path, and a cancel button.
+
+## Features
+
+- Alt text, title, source URL, and date embedded into downloaded images
+- Configurable output directory (`--output` / `-o`)
+- Configurable concurrency (`--workers` / `-w`)
 
 ## Run modes
 

--- a/XKCD_archiver/downloadXKCD.py
+++ b/XKCD_archiver/downloadXKCD.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from XKCD_archiver.downloader import Downloader
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 
 def is_venv() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xkcd-archiver"
-version = "3.0.0"
+version = "3.1.0"
 description = "Downloads every XKCD comic"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Bump version to 3.1.0 in pyproject.toml and downloadXKCD.py
- Add CHANGELOG entry for 3.1.0
- Update README with CLI flags, features list, and TUI cancel mention